### PR TITLE
app: serve over 8080 for testing

### DIFF
--- a/kwoc/app.py
+++ b/kwoc/app.py
@@ -78,4 +78,4 @@ def mentor_form():
 # # above three lines are IMPORTANT
 
 if __name__ == '__main__' and "RUNNING_PROD" not in os.environ:
-    app.run(host='0.0.0.0', port=80)
+    app.run(host='0.0.0.0', port=8080)


### PR DESCRIPTION
We are using gunicorn kwoc.app:app to run the flask app on server and
thus we don't require this so instead make it more suited for testing
purposes.

