### PR TITLE
app: run on port 8080 instead of 80

### DIFF
--- a/kwoc/app.py
+++ b/kwoc/app.py
@@ -78,4 +78,4 @@ def mentor_form():
 # # above three lines are IMPORTANT
 
 if __name__ == '__main__' and "RUNNING_PROD" not in os.environ:
-    app.run(host='0.0.0.0', port=80)
+    app.run(host='0.0.0.0')


### PR DESCRIPTION
Running on port 80 requires admin which is unnecessary for development.
Plus we are using gunicorn which doesn't require running the code as it
is using `python kwoc/app.py`.

