### PR TITLE
fixed loader name

### DIFF
--- a/templates/mentor_form.html
+++ b/templates/mentor_form.html
@@ -373,7 +373,7 @@ function send(form){
       request.open("POST", url , true);
       request.send(data);
       $(".modal-title").html("Processing");
-      $("#reg_msg").html('<img src="/static/images/loading.gif"> </img>');
+      $("#reg_msg").html('<img src="/static/images/loader.gif"> </img>');
       $('#myModal').modal('toggle');
       form.reset()
       return true;


### PR DESCRIPTION
The loader gif is actually named `loader.gif` but was wrongly linked to `loading.gif` which did not exist.