### PR TITLE
http to https for google fonts

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -48,9 +48,9 @@ Table of contents
 /* ===================================
     Google font
 ====================================== */
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700,800);
-@import url(http://fonts.googleapis.com/css?family=Oswald:400,300,700);
-@import url(http://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,300italic,700);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700,800);
+@import url(https://fonts.googleapis.com/css?family=Oswald:400,300,700);
+@import url(https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,300italic,700);
 
 /* ===================================
     Reset


### PR DESCRIPTION
The projects had Open Sans fonts requesting from an `http://........`. leading to failure on https mode
Changed it to `https://....`